### PR TITLE
Add version even if cdn url is not available

### DIFF
--- a/shop/utils.py
+++ b/shop/utils.py
@@ -191,15 +191,16 @@ def cdnify(url):
     "CDNify a url"
     cdn_url = current_app.config.get('CDN')
     version = current_app.config.get('VERSION')
-    if not cdn_url or not url or not url.startswith('/'):
+    if not url or not url.startswith('/'):
         # Only urls relative to root can be changes
         return url
 
-    res_url = "%s%s" % (cdn_url, url)
+    if cdn_url:
+        url = "%s%s" % (cdn_url, url)
     if version:
         # TODO: Handle query params in url
-        res_url += '?version=%s' % version
-    return res_url
+        url += '?version=%s' % version
+    return url
 
 
 class Pagination(object):


### PR DESCRIPTION
This is helpful in invalidating cache if complete website is being
served from some cdn

[#133705941]